### PR TITLE
ci: Dependabotを導入

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## 概要
GitHubのDependabotを導入し、依存関係の自動更新を有効化する。

## 変更内容の詳細
`.github/dependabot.yml` を追加し、以下の2つのエコシステムを監視対象に設定：

| エコシステム | チェック頻度 | PR上限 | ラベル |
|-------------|-------------|--------|--------|
| npm | 週1回 | 10件 | `dependencies` |
| github-actions | 週1回 | - | `dependencies`, `github-actions` |

### 設定のポイント
- **weekly**: PR数とセキュリティ対応のバランスを考慮
- **open-pull-requests-limit: 10**: PRが溢れないように制限
- **labels**: フィルタリング・自動化用にラベルを付与

## スクリーンショット
なし

## 備考
- マージ後、GitHubが自動的にDependabotを有効化
- メジャー/マイナー/パッチすべてのバージョン更新がPR対象