### PR TITLE
ci: Dependabot設定を改善

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -15,3 +19,7 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for minor updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要
Dependabotの更新頻度を最適化し、マイナーバージョン更新の自動マージを導入する。

## 変更内容の詳細
### パッチバージョンの無視
- npm、github-actions両方でパッチバージョン更新（`x.y.z` → `x.y.z+1`）を無視
- セキュリティリスクの低いパッチ更新によるPRの乱立を防止

### マイナーバージョンの自動マージ
- 新規ワークフロー `dependabot-auto-merge.yml` を追加
- マイナーバージョン更新はCI通過後に自動でsquashマージ
- `dependabot/fetch-metadata@v2` でバージョン種別を判定

### 更新ポリシー
| バージョン | 動作 |
|-----------|------|
| パッチ | 無視（PRなし） |
| マイナー | CI通過後オートマージ |
| メジャー | PR作成のみ（手動マージ） |

## スクリーンショット
なし

## 備考
- リポジトリ設定で「Allow auto-merge」の有効化が必要
- ブランチ保護ルールでCIを必須チェックに設定済み